### PR TITLE
Fix the includes

### DIFF
--- a/pt3_pci.c
+++ b/pt3_pci.c
@@ -36,7 +36,7 @@
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,23)
 #include <linux/freezer.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,36)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,32)
 #include <linux/smp_lock.h>
 #endif
 #else


### PR DESCRIPTION
特定のカーネルで `linux/smp_lock.h` がincludeされていないとmake時にエラーが発生する問題を修正しました。

```
/tmp/pt3/pt3_pci.c:826: error: implicit declaration of function ‘lock_kernel’
/tmp/pt3/pt3_pci.c:834: error: implicit declaration of function ‘unlock_kernel’
```
