### PR TITLE
Fix compile error on Linux 4.2 or above

### DIFF
--- a/pt3_pci.h
+++ b/pt3_pci.h
@@ -21,6 +21,9 @@
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,37)
 void * pt3_vzalloc(unsigned long size);
 #else
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,2,0)
+#include <linux/vmalloc.h>
+#endif
 #define pt3_vzalloc vzalloc
 #endif
 


### PR DESCRIPTION
```
% make
make -C /lib/modules/`uname -r`/build M=`pwd` V=0 modules
make[1]: Entering directory '/usr/lib/modules/4.2.5-1-ARCH/build'
  CC [M]  /home/eagletmt/.ghq/github.com/m-tsudo/pt3/pt3_pci.o
  CC [M]  /home/eagletmt/.ghq/github.com/m-tsudo/pt3/pt3_bus.o
In file included from /home/eagletmt/.ghq/github.com/m-tsudo/pt3/pt3_bus.c:38:0:
/home/eagletmt/.ghq/github.com/m-tsudo/pt3/pt3_bus.c: In function ‘create_pt3_bus’:
/home/eagletmt/.ghq/github.com/m-tsudo/pt3/pt3_pci.h:24:21: error: implicit declaration of function ‘vzalloc’ [-Werror=implicit-function-declaration]
 #define pt3_vzalloc vzalloc
                     ^
/home/eagletmt/.ghq/github.com/m-tsudo/pt3/pt3_bus.c:218:8: note: in expansion of macro ‘pt3_vzalloc’
  bus = pt3_vzalloc(sizeof(PT3_BUS));
        ^
/home/eagletmt/.ghq/github.com/m-tsudo/pt3/pt3_bus.c:218:6: warning: assignment makes pointer from integer without a cast [-Wint-conversion]
  bus = pt3_vzalloc(sizeof(PT3_BUS));
      ^
/home/eagletmt/.ghq/github.com/m-tsudo/pt3/pt3_bus.c: In function ‘free_pt3_bus’:
/home/eagletmt/.ghq/github.com/m-tsudo/pt3/pt3_bus.c:239:2: error: implicit declaration of function ‘vfree’ [-Werror=implicit-function-declaration]
  vfree(bus);
  ^
cc1: some warnings being treated as errors
```