### PR TITLE
Support 4.12 or above.

### DIFF
--- a/pt3_dma.c
+++ b/pt3_dma.c
@@ -26,13 +26,17 @@
 #include <linux/version.h>
 #include <linux/mutex.h>
 #include <linux/sched.h>
+#include <linux/uaccess.h>
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0)
 #include <asm/system.h>
 #endif
 #include <asm/io.h>
 #include <asm/irq.h>
-#include <asm/uaccess.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0)
+ #include <asm/uaccess.h>
+#endif
 
 #include "pt3_com.h"
 #include "pt3_pci.h"

--- a/pt3_pci.c
+++ b/pt3_pci.c
@@ -25,13 +25,17 @@
 #include <linux/interrupt.h>
 #include <linux/version.h>
 #include <linux/mutex.h>
+#include <linux/uaccess.h>
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0)
  #include <asm/system.h>
 #endif
 #include <asm/io.h>
 #include <asm/irq.h>
-#include <asm/uaccess.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0)
+ #include <asm/uaccess.h>
+#endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,11)
  typedef struct pm_message {


### PR DESCRIPTION
Linux kernel 4.12 removes copy_{to,from}_user from asm/uaccess.h.
It placed on linux/uaccess.h now.

See https://github.com/torvalds/linux/commit/701cac61d0250912b89cbc28589969530179099a

```sh
$ make
eval `sed -e "s/\[0\]//" ./dkms.conf`; \  
GREV=`git rev-list HEAD | wc -l 2> /dev/null`; \                                    
if [ $GREV != 0 ] ; then \                
        printf "#define DRV_VERSION \"${PACKAGE_VERSION}rev$GREV\"\n#define DRV_RELDATE \"`git show --date=short --format=%ad | sed -n '1p' 2> /dev/null`\"\n#define DRV_NAME \"${BUILT_MODULE_NAME}\"\n" > version.h; \
else \               
        printf "#define DRV_VERSION \"${PACKAGE_VERSION}\"\n#define DRV_RELDATE \"$PACKAGE_RELDATE\"\n#define DRV_NAME \"${BUILT_MODULE_NAME}\"\n" > version.h; \
fi                   
make -C /lib/modules/`uname -r`/build M=`pwd` V=0 modules                           
make[1]: ディレクトリ '/usr/lib/modules/4.12.3-1-ARCH/build' に入ります             
  CC [M]  /home/toshi/Dev/pt3/pt3_pci.o   
/home/toshi/Dev/pt3/pt3_pci.c: 関数 ‘pt3_do_ioctl’ 内:                              
/home/toshi/Dev/pt3/pt3_pci.c:744:11: エラー: implicit declaration of function ‘copy_from_user’; did you mean ‘raw_copy_from_user’? [-Werror=implicit-function-declaration]
   dummy = copy_from_user(&freq, arg, sizeof(FREQUENCY));                           
           ^~~~~~~~~~~~~~
           raw_copy_from_user
/home/toshi/Dev/pt3/pt3_pci.c:757:11: エラー: implicit declaration of function ‘copy_to_user’; did you mean ‘raw_copy_to_user’? [-Werror=implicit-function-declaration]
   dummy = copy_to_user(arg, &signal, sizeof(int));                                 
           ^~~~~~~~~~~~
           raw_copy_to_user
cc1: some warnings being treated as errors                                          
make[2]: *** [scripts/Makefile.build:303: /home/toshi/Dev/pt3/pt3_pci.o] エラー 1   
make[1]: *** [Makefile:1512: _module_/home/toshi/Dev/pt3] エラー 2                  
make[1]: ディレクトリ '/usr/lib/modules/4.12.3-1-ARCH/build' から出ます             
make: *** [Makefile:12: pt3_drv.ko] エラー 2                                        
```