### PR TITLE
Support kernel version 5.x

### DIFF
--- a/pt3_mx.c
+++ b/pt3_mx.c
@@ -387,7 +387,11 @@ pt3_mx_set_frequency(PT3_MX *mx, __u32 channel, __s32 offset)
 	int catv, locked1, locked2;
 	__u32 number, freq;
 	__u32 real_freq;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
 	struct timeval begin, now;
+#else
+	struct timespec64 begin, now;
+#endif
 
 	status = pt3_tc_set_agc_t(mx->tc, NULL, PT3_TC_AGC_MANUAL);
 	if (status)
@@ -400,10 +404,18 @@ pt3_mx_set_frequency(PT3_MX *mx, __u32 channel, __s32 offset)
 
 	mx_set_frequency(mx, NULL, real_freq);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
 	do_gettimeofday(&begin);
+#else
+	ktime_get_real_ts64(&begin);
+#endif
 	locked1 = locked2 = 0;
 	while (1) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
 		do_gettimeofday(&now);
+#else
+		ktime_get_real_ts64(&now);
+#endif
 		pt3_mx_get_locked1(mx, NULL, &locked1);
 		pt3_mx_get_locked2(mx, NULL, &locked2);
 

--- a/pt3_qm.c
+++ b/pt3_qm.c
@@ -496,7 +496,11 @@ pt3_qm_set_frequency(PT3_QM *qm, __u32 channel, __s32 offset)
 	STATUS status;
 	int bs, locked;
 	__u32 number, freq, freq_khz;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
 	struct timeval begin, now;
+#else
+	struct timespec64 begin, now;
+#endif
 
 	status = pt3_tc_set_agc_s(qm->tc, NULL, PT3_TC_AGC_MANUAL);
 	if (status)
@@ -516,9 +520,17 @@ pt3_qm_set_frequency(PT3_QM *qm, __u32 channel, __s32 offset)
 	if (status)
 		return status;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
 	do_gettimeofday(&begin);
+#else
+	ktime_get_real_ts64(&begin);
+#endif
 	while (1) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
 		do_gettimeofday(&now);
+#else
+		ktime_get_real_ts64(&now);
+#endif
 
 		status = pt3_qm_get_locked(qm, NULL, &locked);
 		if (status)

--- a/pt3_tc.c
+++ b/pt3_tc.c
@@ -755,10 +755,18 @@ free_pt3_tc(PT3_TC *tc)
 }
 
 __u32
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
 time_diff(struct timeval *st, struct timeval *et)
+#else
+time_diff(struct timespec64 *st, struct timespec64 *et)
+#endif
 {
 	__u32 diff;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
 	diff = (et->tv_sec - st->tv_sec) * 1000000 + (et->tv_usec - st->tv_usec);
+#else
+	diff = (et->tv_sec - st->tv_sec) * 1000000 + ((et->tv_nsec / 1000) - (st->tv_nsec / 1000));
+#endif
 #if 0
 	PT3_PRINTK(7, KERN_DEBUG, "time diff = %d\n", diff / 1000);
 #endif

--- a/pt3_tc.h
+++ b/pt3_tc.h
@@ -64,6 +64,10 @@ STATUS pt3_tc_read_cn_s(PT3_TC *tc, PT3_BUS *bus, __u32 *cn);
 STATUS pt3_tc_read_cndat_t(PT3_TC *tc, PT3_BUS *bus, __u32 *cn);
 PT3_TC * create_pt3_tc(PT3_I2C *i2c, __u8 tc_addr, __u8 qm_addr);
 void free_pt3_tc(PT3_TC *tc);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
 __u32 time_diff(struct timeval *st, struct timeval *et);
+#else
+__u32 time_diff(struct timespec64 *st, struct timespec64 *et);
+#endif
 
 #endif


### PR DESCRIPTION
Linux kernel 5.x remove `do_gettimeofday`.

https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=e4b92b108c6cd6b311e4b6e85d6a87a34599a6e3

I implemented the same process as deleted one.
